### PR TITLE
Provide the key also as bytes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         tox_env: ${{ matrix.tox_env }}
     strategy:
       matrix:
-        tox_env: [py27, py35, py36, py37, py38, py39, pypy2, pypy3]
+        tox_env: [py35, py36, py37, py38, py39, py310, py311, py312, pypy3]
 
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         tox_env: ${{ matrix.tox_env }}
     strategy:
       matrix:
-        tox_env: [py35, py36, py37, py38, py39, py310, py311, py312, pypy3]
+        tox_env: [py36, py37, py38, py39, py310, py311, py312, pypy3]
 
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 /.tox/
 /czech_sort.egg-info/
 .hypothesis
+/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 /.tox/
 /czech_sort.egg-info/
+.hypothesis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 (2023-07-11)
+
+- Drop support for Python 2
+
 ## 1.0.1 (2021-08-30)
 
 - Fix bug that prevented sorting strings that contain 'Ł' and/or 'Ø'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0 (2023-07-11)
 
+- Add `bytes_key`
+  (Thanks to @honzajavorek!)
 - Drop support for Python 2
 
 ## 1.0.1 (2021-08-30)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Full API
  This is suitable as a DB-API custom function like the built-in
  `sqlite3` connection's `create_function`.
 
+ WARNING: Do not store the results of this function. The format can change
+ in future versions of `czech_sort`.
+
 
 Compatibility
 -------------

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Full API
  This function is suitable as the `key` for functions like the built-in
  `sorted` or `list.sort`.
 
+### `czech_sort.bytes_key(s)`
+
+ Returns a sort key for a given string, as bytes.
+
+ This is suitable as a DB-API custom function like the built-in
+ `sqlite3` connection's `create_function`.
+
 
 Compatibility
 -------------

--- a/czech_sort/__init__.py
+++ b/czech_sort/__init__.py
@@ -1,3 +1,3 @@
-from .impl import sorted, key
+from .impl import sorted, key, bytes_key
 
-__all__ = ['sorted', 'key']
+__all__ = ['sorted', 'key', 'bytes_key']

--- a/czech_sort/impl.py
+++ b/czech_sort/impl.py
@@ -29,6 +29,10 @@ def sorted(strings):
     return builtins.sorted(strings, key=key)
 
 
+def bytes_key(string):
+    pass
+
+
 nfkd = functools.partial(unicodedata.normalize, 'NFKD')
 HACEK = nfkd('č')[-1]
 

--- a/czech_sort/impl.py
+++ b/czech_sort/impl.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 
 import re
 import functools
+import sys
 import unicodedata
 
 try:
@@ -19,6 +20,9 @@ try:
 except ImportError:
     # Python 2
     import __builtin__ as builtins
+
+str_type = unicode if sys.version_info < (3, 0) else str
+bytes_type = str if sys.version_info < (3, 0) else bytes
 
 
 def sorted(strings):
@@ -46,30 +50,29 @@ def bytes_key(string):
 
 
 def key_to_bytes(multi_level_key):
-    match multi_level_key:
-        case tuple():
-            # Turn individual items into bytes keys, and join them.
-            # After each item, put a `1` byte if there are more items,
-            # and a `0` byte if not.
-            return b'\x01'.join(key_to_bytes(e) for e in multi_level_key) + b'\0'
-        case str():
-            # Encode to UTF-8, add a zero marker at the end.
-            # The marker needs to be "smaller" than anything in the string,
-            # including embedded `0` bytes.
-            # So, the marker is a doubled `0` byte, and any `0` bytes in
-            # the string are "escaped" to `0`-`1`.
-            return multi_level_key.encode().replace(b'\0', b'\0\x01') + b'\0\0'
-        case int():
-            if multi_level_key < 0:
-                # Negative numbers are smallest, start with a `0` byte.
-                return bytes([0]) + multi_level_key.to_bytes(8, signed=True)
-            if multi_level_key >= 254:
-                # Large numbers start with a full byte.
-                return bytes([255]) + multi_level_key.to_bytes(8)
-            # Small non-negative numbers use the remaining byte values.
-            return (multi_level_key + 1).to_bytes(1)
-        case _:
-            raise TypeError(multi_level_key)
+    if isinstance(multi_level_key, tuple):
+        # Turn individual items into bytes keys, and join them.
+        # After each item, put a `1` byte if there are more items,
+        # and a `0` byte if not.
+        return b'\x01'.join(key_to_bytes(e) for e in multi_level_key) + b'\0'
+    elif isinstance(multi_level_key, str_type):
+        # Encode to UTF-8, add a zero marker at the end.
+        # The marker needs to be "smaller" than anything in the string,
+        # including embedded `0` bytes.
+        # So, the marker is a doubled `0` byte, and any `0` bytes in
+        # the string are "escaped" to `0`-`1`.
+        return multi_level_key.encode('utf-8').replace(b'\0', b'\0\x01') + b'\0\0'
+    elif isinstance(multi_level_key, int):
+        if multi_level_key < 0:
+            # Negative numbers are smallest, start with a `0` byte.
+            return bytes_type([0]) + multi_level_key.to_bytes(8, signed=True)
+        if multi_level_key >= 254:
+            # Large numbers start with a full byte.
+            return bytes_type([255]) + multi_level_key.to_bytes(8)
+        # Small non-negative numbers use the remaining byte values.
+        return (multi_level_key + 1).to_bytes(1)
+    else:
+        raise TypeError(multi_level_key)
 
 
 nfkd = functools.partial(unicodedata.normalize, 'NFKD')

--- a/czech_sort/impl.py
+++ b/czech_sort/impl.py
@@ -15,14 +15,7 @@ import functools
 import sys
 import unicodedata
 
-try:
-    import builtins
-except ImportError:
-    # Python 2
-    import __builtin__ as builtins
-
-str_type = unicode if sys.version_info < (3, 0) else str
-bytes_type = str if sys.version_info < (3, 0) else bytes
+import builtins
 
 
 def sorted(strings):
@@ -55,7 +48,7 @@ def key_to_bytes(multi_level_key):
         # After each item, put a `1` byte if there are more items,
         # and a `0` byte if not.
         return b'\x01'.join(key_to_bytes(e) for e in multi_level_key) + b'\0'
-    elif isinstance(multi_level_key, str_type):
+    elif isinstance(multi_level_key, str):
         # Encode to UTF-8, add a zero marker at the end.
         # The marker needs to be "smaller" than anything in the string,
         # including embedded `0` bytes.

--- a/czech_sort/impl.py
+++ b/czech_sort/impl.py
@@ -45,9 +45,8 @@ def bytes_key(string):
 def key_to_bytes(multi_level_key):
     if isinstance(multi_level_key, tuple):
         # Turn individual items into bytes keys, and join them.
-        # After each item, put a `1` byte if there are more items,
-        # and a `0` byte if not.
-        return b'\x01'.join(key_to_bytes(e) for e in multi_level_key) + b'\0'
+        # After each tuple, put a `0` byte.
+        return b''.join(key_to_bytes(e) for e in multi_level_key) + b'\0'
     elif isinstance(multi_level_key, str):
         # Encode to UTF-8, add a zero marker at the end.
         # The marker needs to be "smaller" than anything in the string,

--- a/czech_sort/impl.py
+++ b/czech_sort/impl.py
@@ -57,12 +57,16 @@ def key_to_bytes(multi_level_key):
     elif isinstance(multi_level_key, int):
         if multi_level_key < 0:
             # Negative numbers are smallest, start with a `0` byte.
-            return bytes_type([0]) + multi_level_key.to_bytes(8, signed=True)
+            return bytes([0]) + multi_level_key.to_bytes(
+                8, byteorder='big', signed=True,
+            )
         if multi_level_key >= 254:
             # Large numbers start with a full byte.
-            return bytes_type([255]) + multi_level_key.to_bytes(8)
+            return bytes([255]) + multi_level_key.to_bytes(
+                8, byteorder='big',
+            )
         # Small non-negative numbers use the remaining byte values.
-        return (multi_level_key + 1).to_bytes(1)
+        return (multi_level_key + 1).to_bytes(1, byteorder='big')
     else:
         raise TypeError(multi_level_key)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = czech-sort
-version = 1.0.1
+version = 1.1.0
 
 description = Text sorting function for the Czech language
 long_description = file: README.md, CHANGELOG.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,13 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
 
 [options]
 zip_safe = True
 packages =
     czech_sort
+python_requires = >=3.5
 
 [options.extras_require]
 test = 
@@ -29,7 +29,8 @@ test =
 
 [tox:tox]
 minversion = 3.20.0
-envlist = py27,py35,py36,py37,py38,py39
+envlist = py35,py36,py37,py38,py39,py310,py311,py312
+isolated_build = true
 
 [testenv]
 deps =

--- a/test_czech_sort/test_api.py
+++ b/test_czech_sort/test_api.py
@@ -15,6 +15,11 @@ def test_key():
     assert result == [u'shoda', u'schody', u'sídliště']
 
 
+def test_bytes_key():
+    result = sorted([u'sídliště', u'shoda', u'schody'], key=czech_sort.bytes_key)
+    assert result == [u'shoda', u'schody', u'sídliště']
+
+
 def test_error_bytes():
     with pytest.raises(TypeError):
         czech_sort.sorted([b'a', b'b'])

--- a/test_czech_sort/test_api.py
+++ b/test_czech_sort/test_api.py
@@ -1,5 +1,6 @@
 # For Python 2, we need to declare the encoding: UTF-8, of course.
 
+import sqlite3
 import pytest
 
 import czech_sort
@@ -18,6 +19,21 @@ def test_key():
 def test_bytes_key():
     result = sorted([u'sídliště', u'shoda', u'schody'], key=czech_sort.bytes_key)
     assert result == [u'shoda', u'schody', u'sídliště']
+
+
+def test_bytes_key_db():
+    connection = sqlite3.connect(":memory:")
+    try:
+        connection.create_function("czech_sort", 1, czech_sort.bytes_key)
+        cursor = connection.cursor()
+        cursor.execute("CREATE TABLE items(name)")
+        cursor.executemany("INSERT INTO items VALUES (?)", [(u'sídliště',), (u'shoda',), (u'schody',)])
+        connection.commit()
+        result = cursor.execute("SELECT name FROM items ORDER BY czech_sort(name)").fetchall()
+    finally:
+        connection.close()
+
+    assert result == [(u'shoda',), (u'schody',), (u'sídliště',)]
 
 
 def test_error_bytes():

--- a/test_czech_sort/test_data.py
+++ b/test_czech_sort/test_data.py
@@ -53,7 +53,7 @@ def pytest_generate_tests(metafunc):
     if metafunc.function.__name__ == 'test_sorted':
         metafunc.parametrize(
             'l', [list(l) for l in inputs])
-    if metafunc.function.__name__ == 'test_key':
+    if metafunc.function.__name__ in ('test_key', 'test_bytes_key'):
         metafunc.parametrize(
             's', [c for l in inputs for c in l])
 
@@ -69,27 +69,50 @@ def test_key(s):
     """Assert keys are immutable and well ordered"""
     # Actually, this is a strict type check
     key = czech_sort.key(s)
-    check_key_element(key)
+    check_key_type(key)
 
 
-def check_key_element(t):
+def check_key_type(t):
     if type(t) in (str, int, bool):
         return True
     if sys.version_info < (3, 0) and type(t) is unicode:
         return True
     if type(t) is tuple:
         for c in t:
-            check_key_element(c)
+            check_key_type(c)
         return
     raise AssertionError('{0} is a {1}'.format(t, type(t)))
+
+
+def test_bytes_key(s):
+    """Assert keys are immutable and well ordered"""
+    # Actually, this is a strict type check
+    key = czech_sort.bytes_key(s)
+
+
+def check_bytes_key_type(t):
+    if sys.version_info < (3, 0) and type(t) is str:
+        return True
+    if type(t) is bytes:
+        return True
+    raise AssertionError('{0} is a {1}'.format(t, type(t)))
+
 
 @given(random_string=text())
 def test_sorted_hypothesis(random_string):
     result = czech_sort.sorted(random_string)
     assert type(result) == list
 
+
 @given(random_string=text())
 def test_key_hypothesis(random_string):
     # Actually, this is a strict type check
     key = czech_sort.key(random_string)
-    check_key_element(key)
+    check_key_type(key)
+
+
+@given(random_string=text())
+def test_bytes_key_hypothesis(random_string):
+    # Actually, this is a strict type check
+    key = czech_sort.key(random_string)
+    check_bytes_key_type(key)

--- a/test_czech_sort/test_data.py
+++ b/test_czech_sort/test_data.py
@@ -90,12 +90,12 @@ def test_bytes_key(s):
     key = czech_sort.bytes_key(s)
 
 
-def check_bytes_key_type(t):
+def check_bytes_key_type(b):
     if sys.version_info < (3, 0) and type(t) is str:
         return True
-    if type(t) is bytes:
+    if type(b) is bytes:
         return True
-    raise AssertionError('{0} is a {1}'.format(t, type(t)))
+    raise AssertionError('{0} is a {1}'.format(b, type(b)))
 
 
 @given(random_string=text())
@@ -114,5 +114,5 @@ def test_key_hypothesis(random_string):
 @given(random_string=text())
 def test_bytes_key_hypothesis(random_string):
     # Actually, this is a strict type check
-    key = czech_sort.key(random_string)
+    key = czech_sort.bytes_key(random_string)
     check_bytes_key_type(key)

--- a/test_czech_sort/test_data.py
+++ b/test_czech_sort/test_data.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import sys
 
 from hypothesis import given
-from hypothesis.strategies import text
+from hypothesis.strategies import text, lists
 
 import czech_sort
 
@@ -83,15 +83,9 @@ def check_key_type(t):
 
 
 def test_bytes_key(s):
-    """Assert keys are immutable and well ordered"""
-    # Actually, this is a strict type check
+    """Assert bytes keys are bytes"""
     key = czech_sort.bytes_key(s)
-
-
-def check_bytes_key_type(b):
-    if type(b) is bytes:
-        return True
-    raise AssertionError('{0} is a {1}'.format(b, type(b)))
+    assert isinstance(key, bytes)
 
 
 @given(random_string=text())
@@ -111,4 +105,11 @@ def test_key_hypothesis(random_string):
 def test_bytes_key_hypothesis(random_string):
     # Actually, this is a strict type check
     key = czech_sort.bytes_key(random_string)
-    check_bytes_key_type(key)
+    assert isinstance(key, bytes)
+
+
+@given(strings=lists(text()))
+def test_bytes_key_matches_key_hypothesis(strings):
+    by_key = sorted(strings, key=czech_sort.key)
+    by_bytes_key = sorted(strings, key=czech_sort.bytes_key)
+    assert by_key == by_bytes_key

--- a/test_czech_sort/test_data.py
+++ b/test_czech_sort/test_data.py
@@ -91,7 +91,7 @@ def test_bytes_key(s):
 
 
 def check_bytes_key_type(b):
-    if sys.version_info < (3, 0) and type(t) is str:
+    if sys.version_info < (3, 0) and type(b) is str:
         return True
     if type(b) is bytes:
         return True

--- a/test_czech_sort/test_data.py
+++ b/test_czech_sort/test_data.py
@@ -75,8 +75,6 @@ def test_key(s):
 def check_key_type(t):
     if type(t) in (str, int, bool):
         return True
-    if sys.version_info < (3, 0) and type(t) is unicode:
-        return True
     if type(t) is tuple:
         for c in t:
             check_key_type(c)
@@ -91,8 +89,6 @@ def test_bytes_key(s):
 
 
 def check_bytes_key_type(b):
-    if sys.version_info < (3, 0) and type(b) is str:
-        return True
     if type(b) is bytes:
         return True
     raise AssertionError('{0} is a {1}'.format(b, type(b)))


### PR DESCRIPTION
- [x] basic implementation
- [x] add test with in-memory SQLite, i.e. whether the change actually helps to solve the problem
- [ ] figure out how to rewrite it so that it works in Python 2 🤯 
    - [ ] Python 2 doesn't have `.to_bytes()` on integers, I give up
    - [ ] The work done so far is isolated in ecb5384bf01410318a3a7d009b5a18e4df79dabe (if you'd like to drop support for Python 2.x, we can just drop that commit)