### PR TITLE
Remove the compatibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,6 @@ Full API
  in future versions of `czech_sort`.
 
 
-Compatibility
--------------
-
-The czech-sort library can be used with Python 2.6+ and 3.5+.
-
-Under Python 2, it only accepts `unicode` strings.
-
-
 Installation
 ------------
 


### PR DESCRIPTION
Since Python v2 support is gone, I think we can delete this. We could specify the currently supported Python version range, but since now the range is pretty standard, I don't see value in specifying it in the README explicitly. Those unsure can always check the GitHub Actions config or, better, PyPI classifiers.